### PR TITLE
Fix typo

### DIFF
--- a/src/guide/computed.md
+++ b/src/guide/computed.md
@@ -162,7 +162,7 @@ Par exemple:
     data() {
       return {
         question: '',
-        answer: 'Les questions contiennent généralement un point d'interrogation. ;-)'
+        answer: 'Les questions contiennent généralement un point d\'interrogation. ;-)'
       }
     },
     watch: {


### PR DESCRIPTION
## Description of Problem

A string was not valid since it was created with single quotes
![image](https://user-images.githubusercontent.com/62897760/136944340-3fa5fdf5-cc51-42d9-a242-12f02f25641a.png)


## Proposed Solution

Added escape character \ before the apostrophe in the string
