### PR TITLE
Missing "même" word

### DIFF
--- a/src/guide/composition-api-introduction.md
+++ b/src/guide/composition-api-introduction.md
@@ -125,7 +125,7 @@ setup (props) {
 
   return {
     repositories,
-    getUserRepositories // les fonctions rétournées ont le comportement que methods
+    getUserRepositories // les fonctions rétournées ont le même comportement que methods
   }
 }
 ```


### PR DESCRIPTION
## Description of Problem

Missing "même" word - il manque le mot "même" dans le commentaire

## Proposed Solution

L'ajouter

## Additional Information
